### PR TITLE
Update readme, and small fix for closing tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # MaximumOpenTabs
 
-This plugin automatically closes tabs if amount of opened editor tabs is bigger then set in module settings. You dont need manually close dozens of open tabs. To set nubmer of open tabs you have to install module and go to the Tools->Options->Editor->Maximum Opened Tabs, choose number that you want and click Apply. Thats it.
+Keep your Netbeans environment clear of clutter by only allowing a set amount of tabs to be open at any one time.  To set the number of tabs permitted go to:
+
+Tools->Options->Editor->Maximum Opened Tabs
+
+To streamline your IDE even further it is recommended to also use an Autosave plugin such as http://plugins.netbeans.org/plugin/37077/autosave-module-for-6-9-and-later

--- a/src/org/maxwhite/maxopentabs/MaxOpenTabsPropertyChangeListener.java
+++ b/src/org/maxwhite/maxopentabs/MaxOpenTabsPropertyChangeListener.java
@@ -26,11 +26,9 @@ class MaxOpenTabsPropertyChangeListener implements PropertyChangeListener {
         if( pce.getPropertyName().equalsIgnoreCase("focusGained") ) {
             WindowManager wm  = WindowManager.getDefault();
             List<? extends JTextComponent> editorComponents =  EditorRegistry.componentList();
-            if( editorComponents.size() > MAX_OPENED_TABS) {
+            while (editorComponents.size() > MAX_OPENED_TABS) {
                 NbEditorUtilities.getOuterTopComponent(editorComponents.get(editorComponents.size()-1)).close();
-             }
+            }
         }
-        
     }
-    
 }


### PR DESCRIPTION
Cleaned-up the readme wording and also added the recommendation to use an autosave plugin.

Attempt to keep closing tabs until the set value is reached, not just one tab each time a new tab opens.
